### PR TITLE
require python 3.8 for dependency

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,6 +1,5 @@
-FROM python:3.7
+FROM python:3.8
 
 WORKDIR /usr/src/app
-RUN mkdir -p src
 COPY requirements.txt requirements.txt
 RUN pip3 install -r requirements.txt


### PR DESCRIPTION
The dependency library requires python 3.8 to run and to be compatible with model from the Kepler Model Server.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>