### PR TITLE
modify model config to comply with Kepler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,6 @@ CTR_CMD :=$(or $(shell which podman 2>/dev/null), $(shell which docker 2>/dev/nu
 CTR_CMD = docker
 build:
 	$(CTR_CMD) build -t $(IMAGE_REPO):$(IMAGE_VERSION) .
+
+test:
+	python src/estimator_test.py

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This python will serve a PowerReequest from model package in Kepler exporter as 
 type PowerRequest struct {
     ModelName       string      `json:"model_name"`
     MetricNames     []string    `json:"metrics"`
-    PodMetricValues [][]float32 `json:"values"`
+    ContainerMetricValues [][]float32 `json:"values"`
     CorePower       []float32   `json:"core_power"`
     DRAMPower       []float32   `json:"dram_power"`
     UncorePower     []float32   `json:"uncore_power"`

--- a/deploy/BPFOnly/configmap.yaml
+++ b/deploy/BPFOnly/configmap.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: kepler-estimator-cfm
-data:
-  MODEL_SERVER_URL: kepler-model-server.monitoring.cluster.local
-  DynComponentPower: https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-server/main/tests/test_models/DynComponentPower/BPFOnly/ScikitMixed.zip

--- a/deploy/CgroupOnly/configmap.yaml
+++ b/deploy/CgroupOnly/configmap.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: kepler-estimator-cfm
-data:
-  MODEL_SERVER_URL: kepler-model-server.monitoring.cluster.local
-  DynComponentPower: https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-server/main/tests/test_models/DynComponentPower/CgroupOnly/ScikitMixed.zip

--- a/deploy/CounterOnly/configmap.yaml
+++ b/deploy/CounterOnly/configmap.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: kepler-estimator-cfm
-data:
-  MODEL_SERVER_URL: kepler-model-server.monitoring.cluster.local
-  DynComponentPower: https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-server/main/tests/test_models/DynComponentPower/CounterOnly/ScikitMixed.zip

--- a/deploy/patch.yaml
+++ b/deploy/patch.yaml
@@ -29,4 +29,4 @@ spec:
         name: tmp
       - name: cfm
         configMap:
-          name: kepler-estimator-cfm
+          name: kepler-cfm

--- a/deploy/test-jobs-with-init.yaml
+++ b/deploy/test-jobs-with-init.yaml
@@ -1,3 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kepler-cfm
+data:
+  MODEL_CONFIG: |
+    POD_COMPONENTS_ESTIMATOR=true
+    POD_COMPONENTS_INIT_URL=https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-server/main/tests/test_models/DynComponentPower/CgroupOnly/ScikitMixed.zip
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -6,7 +15,7 @@ spec:
   template:
     spec:
       containers:
-      - image: quay.io/sustainable_computing_io/kepler_estimator:latest
+      - image: quay.io/sustainable_computing_io/kepler-estimator:latest
         imagePullPolicy: IfNotPresent
         name: estimator
         volumeMounts:
@@ -22,4 +31,4 @@ spec:
         name: tmp
       - name: cfm
         configMap:
-          name: kepler-estimator-cfm
+          name: kepler-cfm

--- a/deploy/test-jobs-with-init.yaml
+++ b/deploy/test-jobs-with-init.yaml
@@ -4,8 +4,8 @@ metadata:
   name: kepler-cfm
 data:
   MODEL_CONFIG: |
-    POD_COMPONENTS_ESTIMATOR=true
-    POD_COMPONENTS_INIT_URL=https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-server/main/tests/test_models/DynComponentPower/CgroupOnly/ScikitMixed.zip
+    CONTAINER_COMPONENTS_ESTIMATOR=true
+    CONTAINER_COMPONENTS_INIT_URL=https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-server/main/tests/test_models/DynComponentPower/CgroupOnly/ScikitMixed.zip
 ---
 apiVersion: batch/v1
 kind: Job

--- a/deploy/test-jobs-with-server.yaml
+++ b/deploy/test-jobs-with-server.yaml
@@ -1,3 +1,64 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kepler-model-server-cfm
+data:
+  MODEL_PATH: models
+  INITIAL_MODELS_LOC: https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-server/main/tests/test_models
+  INITIAL_MODEL_NAMES: |
+    AbsComponentModelWeight=KerasCompWeightFullPipeline
+    AbsComponentPower=KerasCompFullPipeline
+    DynComponentPower=ScikitMixed
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: model-server
+  labels:
+    app.kubernetes.io/component: model-server
+    app.kubernetes.io/name: kepler-model-server
+spec:
+  volumes:
+  - name: cfm
+    configMap:
+      name: kepler-model-server-cfm
+  containers:
+  - name: server-api
+    image: quay.io/sustainable_computing_io/kepler-model-server:latest
+    imagePullPolicy: Always
+    ports:
+    - containerPort: 8100
+    volumeMounts:
+      - name: cfm
+        mountPath: /etc/config
+        readOnly: true
+    command: ["python3.8",  "model_server.py"]
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: kepler-model-server
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/component: model-server
+    app.kubernetes.io/name: kepler-model-server
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/component: model-server
+    app.kubernetes.io/name: kepler-model-server
+  ports:
+  - name: http
+    port: 8100
+    targetPort: http
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kepler-cfm
+data:
+  MODEL_SERVER_ENABLE: true
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -5,15 +66,27 @@ metadata:
 spec:
   template:
     spec:
+      initContainers:
+          - name: wait-for-model-server
+            image: stefanevinance/wait-for-200
+            env:
+              - name: URL
+                value: http://model-server.default.svc.cluster.local:8100/best-models
       containers:
-      - image: quay.io/sustainable_computing_io/kepler_estimator:latest
+      - image: quay.io/sustainable_computing_io/kepler-estimator:latest
         imagePullPolicy: IfNotPresent
         name: estimator
         volumeMounts:
         - mountPath: /tmp
           name: tmp
+        - name: cfm
+          mountPath: /etc/config
+          readOnly: true
         command: ["python3", "src/estimator_test.py"]
       restartPolicy: Never
       volumes:
       - emptyDir: {}
         name: tmp
+      - name: cfm
+        configMap:
+          name: kepler-cfm

--- a/src/archived_model.py
+++ b/src/archived_model.py
@@ -6,7 +6,7 @@ util_path = os.path.join(os.path.dirname(__file__), 'model')
 sys.path.append(util_path)
 
 from model_server_connector import unpack, ModelOutputType
-from util.config import getConfig
+from util.config import get_init_model
 from model.common import load_metadata
 
 failed_list = []
@@ -57,6 +57,9 @@ def is_valid_model(metrics, metadata, filters):
                 return False
     return True
 
+def reset_failed_list():
+     global failed_list
+     failed_list = []
 
 def get_achived_model(power_request):  
     global failed_list
@@ -64,9 +67,11 @@ def get_achived_model(power_request):
     if output_type_name in failed_list:
         return None
     output_type = ModelOutputType[power_request.output_type]
-    url = getConfig(output_type_name, None)
-    if url is None:
+    url = get_init_model(output_type_name)
+    if url == "":
+        print("No URL set for ", output_type_name)
         return None
+    print("Try getting archieved model from URL: {} for {}".format(url, output_type_name))
     response = requests.get(url)
     if response.status_code != 200:
         return None

--- a/src/estimator.py
+++ b/src/estimator.py
@@ -3,7 +3,6 @@ import os
 import shutil
 
 import sys
-from unicodedata import name
 import pandas as pd
 
 fpath = os.path.join(os.path.dirname(__file__), 'model')
@@ -35,6 +34,7 @@ import signal
 from model_server_connector import ModelOutputType, is_weight_output, make_request, get_output_path
 from archived_model import get_achived_model
 from model.load import load_model
+from util.config import set_env_from_model_config
 
 loaded_model = dict()
 
@@ -117,6 +117,7 @@ def sig_handler(signum, frame) -> None:
 import argparse
 
 if __name__ == '__main__':
+    set_env_from_model_config()
     clean_socket()
     signal.signal(signal.SIGTERM, sig_handler)
     try:

--- a/src/estimator_test.py
+++ b/src/estimator_test.py
@@ -143,7 +143,7 @@ if __name__ == '__main__':
         power_request = json.loads(data, object_hook = lambda d : PowerRequest(**d))
         output_path = get_achived_model(power_request)
         assert output_path is None, "model should be invalid\n {}".format(output_path)
-        os.environ['MODEL_CONFIG'] = "POD_COMPONENTS_ESTIMATOR=true\nPOD_COMPONENTS_INIT_URL=https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-server/main/tests/test_models/DynComponentPower/CgroupOnly/ScikitMixed.zip\n"
+        os.environ['MODEL_CONFIG'] = "CONTAINER_COMPONENTS_ESTIMATOR=true\nCONTAINER_COMPONENTS_INIT_URL=https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-server/main/tests/test_models/DynComponentPower/CgroupOnly/ScikitMixed.zip\n"
         set_env_from_model_config()
         reset_failed_list()
         if output_type_name in loaded_model:

--- a/src/util/config.py
+++ b/src/util/config.py
@@ -19,6 +19,29 @@ MNT_PATH = "/mnt"
 # can be read only (for configmap mount)
 CONFIG_PATH = "/etc/config"
 
+modelItemNameMap = {
+    "Abs": "NODE_TOTAL",
+    "AbsComponent": "NODE_COMPOENTS",
+    "Dyn": "POD_TOTAL",
+    "DynComponent": "POD_COMPONENTS"
+}
+
+modelTypeNameMap = {
+    "Power": "POWER",
+    "ModelWeight": "MODEL_WEIGHT"
+}
+
+modelEnvMap = {"{}{}".format(modelItemKey, modelTypeKey): "{}_{}".format(modelItemValue, modelTypeValue) for modelItemKey, modelItemValue in modelItemNameMap.items() for modelTypeKey, modelTypeValue in modelTypeNameMap.items() }
+estimatorKeyMap = {"{}Power".format(modelItemKey): "{}_ESTIMATOR".format(modelItemNameMap[modelItemKey]) for modelItemKey in modelItemNameMap.keys()}
+initUrlKeyMap = {"{}Power".format(modelItemKey): "{}_INIT_URL".format(modelItemNameMap[modelItemKey]) for modelItemKey in modelItemNameMap.keys()}
+
+MODEL_SERVER_SVC = "kepler-model-server.monitoring.cluster.local"
+DEFAULT_MODEL_SERVER_PORT = 8100
+MODEL_SERVER_ENDPOINT = 'http://{}:{}'.format(MODEL_SERVER_SVC, DEFAULT_MODEL_SERVER_PORT)
+MODEL_SERVER_MODEL_REQ_PATH = "/model"
+MODEL_SERVER_MODEL_LIST_PATH = "/best-models"
+MODEL_SERVER_ENABLE = False
+
 def getConfig(key, default):
     # check configmap path
     file = os.path.join(CONFIG_PATH, key)
@@ -42,3 +65,43 @@ if not os.path.exists(MNT_PATH) or not os.access(MNT_PATH, os.W_OK):
 print("mount path: ", MNT_PATH)
 
 CONFIG_PATH = getConfig('CONFIG_PATH', CONFIG_PATH)
+
+def is_model_server_enabled():
+    return getConfig('MODEL_SERVER_ENABLE', "false").lower() == "true"
+
+def _model_server_endpoint():
+    MODEL_SERVER_URL = getConfig('MODEL_SERVER_URL', MODEL_SERVER_SVC)
+    if MODEL_SERVER_URL == MODEL_SERVER_SVC:
+        MODEL_SERVER_PORT = getConfig('MODEL_SERVER_PORT', DEFAULT_MODEL_SERVER_PORT)
+        MODEL_SERVER_PORT = int(MODEL_SERVER_PORT)
+        modelServerEndpoint = 'http://{}:{}'.format(MODEL_SERVER_URL, MODEL_SERVER_PORT)
+    else:
+        modelServerEndpoint = MODEL_SERVER_URL
+    return modelServerEndpoint
+
+def get_model_server_req_endpoint():
+    return _model_server_endpoint() + getConfig('MODEL_SERVER_MODEL_REQ_PATH', MODEL_SERVER_MODEL_REQ_PATH)
+
+def get_model_server_list_endpoint():
+    return _model_server_endpoint() + getConfig('MODEL_SERVER_MODEL_LIST_PATH', MODEL_SERVER_MODEL_LIST_PATH)
+
+# set_env_from_model_config: extract environment values based on environment key MODEL_CONFIG
+def set_env_from_model_config():
+    model_config = getConfig('MODEL_CONFIG', "")
+    if model_config != "":
+        lines = model_config.splitlines()
+        for line in lines:
+            splits = line.split('=')
+            if len(splits) > 1:
+                os.environ[splits[0]] = splits[1]
+                print("set {} to {}.".format(splits[0], splits[1]))
+
+# get_init_model: get initial model from URL if estimator is enabled
+def get_init_model(output_type):
+    if output_type in estimatorKeyMap:
+        enabled = getConfig(estimatorKeyMap[output_type], "false").lower() == "true"
+        if enabled:
+            return getConfig(initUrlKeyMap[output_type], "")
+        else:
+            print("{} is not enaled".format(output_type))
+    return ""

--- a/src/util/config.py
+++ b/src/util/config.py
@@ -22,8 +22,8 @@ CONFIG_PATH = "/etc/config"
 modelItemNameMap = {
     "Abs": "NODE_TOTAL",
     "AbsComponent": "NODE_COMPOENTS",
-    "Dyn": "POD_TOTAL",
-    "DynComponent": "POD_COMPONENTS"
+    "Dyn": "CONTAINER_TOTAL",
+    "DynComponent": "CONTAINER_COMPONENTS"
 }
 
 modelTypeNameMap = {


### PR DESCRIPTION
This PR modify the configuration of kepler-estimator in a corresponding way to Kepler configuration for integration (refer to the discussion here: https://github.com/sustainable-computing-io/kepler/discussions/393). 

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>