### PR TITLE
change config path to match kepler exporter

### DIFF
--- a/deploy/patch.yaml
+++ b/deploy/patch.yaml
@@ -32,7 +32,7 @@ spec:
         name: estimator
         volumeMounts:
         - name: cfm
-          mountPath: /etc/config
+          mountPath: /etc/kepler/kepler.config
           readOnly: true
         - mountPath: /tmp
           name: tmp

--- a/deploy/test-jobs-with-init.yaml
+++ b/deploy/test-jobs-with-init.yaml
@@ -22,7 +22,7 @@ spec:
         - mountPath: /tmp
           name: tmp
         - name: cfm
-          mountPath: /etc/config
+          mountPath: /etc/kepler/kepler.config
           readOnly: true
         command: ["python3", "src/estimator_test.py"]
       restartPolicy: Never

--- a/deploy/test-jobs-with-server.yaml
+++ b/deploy/test-jobs-with-server.yaml
@@ -30,7 +30,7 @@ spec:
         - mountPath: /tmp
           name: tmp
         - name: cfm
-          mountPath: /etc/config
+          mountPath: /etc/kepler/kepler.config
           readOnly: true
         command: ["python3", "src/estimator_test.py"]
       restartPolicy: Never

--- a/src/util/config.py
+++ b/src/util/config.py
@@ -17,7 +17,7 @@ import os
 # must be writable (for shared volume mount)
 MNT_PATH = "/mnt"
 # can be read only (for configmap mount)
-CONFIG_PATH = "/etc/config"
+CONFIG_PATH = "/etc/kepler/kepler.config"
 
 modelItemNameMap = {
     "Abs": "NODE_TOTAL",


### PR DESCRIPTION
Related to path change on kepler exporter in PR https://github.com/sustainable-computing-io/kepler/pull/566, there is also a path change defined in the estimator patch.

This PR made a path change in the src code to read the config from the expecting path. 

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>